### PR TITLE
fix: add country body field in POST /point-data/dynamic call

### DIFF
--- a/floodpipeline/load.py
+++ b/floodpipeline/load.py
@@ -459,6 +459,7 @@ class Load:
                             "dynamicPointData": station_forecasts[indicator],
                             "pointDataCategory": "glofas_stations",
                             "disasterType": "floods",
+                            "countryCodeISO3": country,
                             "date": upload_time,
                         }
                         self.ibf_api_post_request("point-data/dynamic", body=body)
@@ -593,6 +594,7 @@ class Load:
                 "dynamicPointData": station_forecasts[indicator],
                 "pointDataCategory": "glofas_stations",
                 "disasterType": "floods",
+                "countryCodeISO3": country,
                 "date": upload_time,
             }
             self.ibf_api_post_request("point-data/dynamic", body=body)


### PR DESCRIPTION
@p-phung @jmargutt @gulfaraz This change should fix the API error. 
- I recently made a small change in the POST /point-data/dynamic endpoint, namely that countryCodeISO3 is now a required body field. 
- This is because this endpoint is used in flash-floods, where we extended from one country (MWI) to a 2nd country (ETH). 
- I adjusted the flash-floods pipeline, but forgot that the floods pipeline was also using this endpoint.
- Simply adding country in the 2 places I found where this endpoint is called should resolve it. 
- I am however not familiar with how to functionallty test or compile this code.